### PR TITLE
Correction policier + halo de lumière

### DIFF
--- a/Assets/Editor/PolicierAIEditor.cs
+++ b/Assets/Editor/PolicierAIEditor.cs
@@ -13,8 +13,8 @@ public class PolicierAIEditor : Editor
         Handles.color = Color.grey;
         Handles.DrawWireArc(ai.transform.position, Vector3.forward, Vector3.left, 360, ai.viewDistance);
 
-        Vector3 angleA = ai.DirFromAngle(45, false);
-        Vector3 angleB = ai.DirFromAngle(135, false);
+        Vector3 angleA = ai.DirFromAngle(90 + ai.viewAngle / 2, false);
+        Vector3 angleB = ai.DirFromAngle(90 - ai.viewAngle / 2, false);
         
         Handles.DrawLine(ai.transform.position, ai.transform.position + angleA * ai.viewDistance);
         Handles.DrawLine(ai.transform.position, ai.transform.position + angleB * ai.viewDistance);

--- a/Assets/Prefab/Ennemies/Policier.prefab
+++ b/Assets/Prefab/Ennemies/Policier.prefab
@@ -49,13 +49,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxSpeed: 3
   TempsDePause: 2
-  player: {fileID: 0}
   viewDistance: 5
+  viewAngle: 120
   layerMask:
     serializedVersion: 2
     m_Bits: 1
   BallePrefab: {fileID: 6532026929992734326, guid: bf984b202a716254983a2af2b9e8eb49,
     type: 3}
+  waitingSecondsBeforeShoot: 0.3
   shootSpeed: 20
 --- !u!212 &3190405453620607027
 SpriteRenderer:

--- a/Assets/Scenes/Chapitre 1 - Niveau 1.unity
+++ b/Assets/Scenes/Chapitre 1 - Niveau 1.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 0
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -3937,6 +3937,7 @@ MonoBehaviour:
   fading: {fileID: 289012746}
   fadingSpeed: 1
   globalLightPostApo: {fileID: 543293370}
+  lightBouclier: {fileID: 129591568}
 --- !u!1 &193256089
 GameObject:
   m_ObjectHideFlags: 0
@@ -5138,6 +5139,87 @@ Transform:
   m_Father: {fileID: 1812685425}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &247125960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 247125961}
+  - component: {fileID: 247125962}
+  m_Layer: 9
+  m_Name: Fond
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &247125961
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247125960}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 23.13, y: 11.254, z: 0}
+  m_LocalScale: {x: 56.36584, y: 29.063126, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1520314764}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &247125962
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247125960}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1240284175
+  m_SortingLayer: -9
+  m_SortingOrder: -10
+  m_Sprite: {fileID: 21300000, guid: e63ffd06f3cee374080407d4eda013eb, type: 3}
+  m_Color: {r: 0.0738252, g: 0.08197522, b: 0.1981132, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &248790239
 GameObject:
   m_ObjectHideFlags: 0
@@ -31669,6 +31751,7 @@ Transform:
   - {fileID: 1198830077}
   - {fileID: 2029729143}
   - {fileID: 85816909}
+  - {fileID: 247125961}
   m_Father: {fileID: 1781529868}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Niveau 2 -IntroPontGravité.unity
+++ b/Assets/Scenes/Niveau 2 -IntroPontGravité.unity
@@ -2040,6 +2040,11 @@ PrefabInstance:
       propertyPath: layerMask.m_Bits
       value: 512
       objectReference: {fileID: 0}
+    - target: {fileID: 3190405453620607029, guid: 7da330d0de1e7ab40bae39f67dae3dc4,
+        type: 3}
+      propertyPath: viewAngle
+      value: 120
+      objectReference: {fileID: 0}
     - target: {fileID: 3190405454161081445, guid: 7da330d0de1e7ab40bae39f67dae3dc4,
         type: 3}
       propertyPath: m_Layer

--- a/Assets/Scenes/Niveau 2 -IntroPontGravité.unity
+++ b/Assets/Scenes/Niveau 2 -IntroPontGravité.unity
@@ -1960,6 +1960,11 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 9
       objectReference: {fileID: 0}
+    - target: {fileID: 3190405453620607026, guid: 7da330d0de1e7ab40bae39f67dae3dc4,
+        type: 3}
+      propertyPath: m_IsTrigger
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3190405453620607028, guid: 7da330d0de1e7ab40bae39f67dae3dc4,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/CameraFollowing.cs
+++ b/Assets/Scripts/CameraFollowing.cs
@@ -14,6 +14,7 @@ public class CameraFollowing : MonoBehaviour
     public Image fading;
     public float fadingSpeed;
     public Light2D globalLightPostApo;
+    public Light2D lightBouclier;
 
     private bool following = true;
 
@@ -127,6 +128,7 @@ public class CameraFollowing : MonoBehaviour
 
     IEnumerator TomberBouclier(Transform bouclier, GameObject player)
     {
+        lightBouclier.enabled = false;
         Vector2 targetPosP = new Vector2(player.transform.position.x, 0);
         Vector2 targetPosB = new Vector2(bouclier.transform.position.x, 0);
         float timeStart = Time.time;

--- a/Assets/Scripts/Hero.cs
+++ b/Assets/Scripts/Hero.cs
@@ -387,8 +387,16 @@ public class Hero : MonoBehaviour
     private void OnTriggerEnter2D(Collider2D collision)
     {
         // DeadZones
-
         if (collision.tag == "Dead" && anim.GetBool("Mort") == false)
+        {
+            StartCoroutine(DeathMrX());
+        }
+    }
+
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        // DeadZones
+        if (collision.gameObject.tag == "Ennemy" && anim.GetBool("Mort") == false)
         {
             StartCoroutine(DeathMrX());
         }

--- a/Assets/Scripts/PolicierAI.cs
+++ b/Assets/Scripts/PolicierAI.cs
@@ -9,6 +9,7 @@ public class PolicierAI : MonoBehaviour
     public float TempsDePause = 2;
     [Header("Recherche")]
     public float viewDistance;
+    public int viewAngle;
     public LayerMask layerMask;
     [Header("Tir")]
     public GameObject BallePrefab;
@@ -81,7 +82,7 @@ public class PolicierAI : MonoBehaviour
         {
             float angle = Vector2.Angle(transform.right, (player.transform.position - transform.position).normalized);
 
-            if ((directionGauche && angle > 135) || (!directionGauche && angle < 45)) // Vérification de l'angle (cône de vision)
+            if ((directionGauche && angle > 90 + viewAngle / 2) || (!directionGauche && angle < 90 - viewAngle / 2)) // Vérification de l'angle (cône de vision)
             {
                 if (!(Physics2D.Raycast(transform.position, (player.transform.position - transform.position), dist, layerMask))) // Vérification de la présence d'obstacles
                 {


### PR DESCRIPTION
• Le halo de lumière du bouclier disparaît à l'appuie du bouton
• Le policier peut maintenant facilement changer d'angle de vision
    - Sa vision est maintenant de 120°
• Le policier tue maintenant le joueur au contact